### PR TITLE
Update torchtitan example

### DIFF
--- a/examples/train_llama_torchtitan/README.md
+++ b/examples/train_llama_torchtitan/README.md
@@ -14,10 +14,15 @@ the same with gSPMD.
 
 ## Install dependencies
 
+Ensure you are using python 3.11 or above by checking `python --version`.
+
+Then install dependencies:
+
 ```bash
 pip install jax[tpu] -f https://storage.googleapis.com/jax-releases/libtpu_releases.html
-pip install optax fire tensorflow tensorboard-plugin-profile
+pip install optax fire flax triton 
 pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cpu
+pip install tensorflow tensorboard-plugin-profile 
 
 cd ~
 git clone https://github.com/pytorch/torchtitan.git
@@ -39,7 +44,7 @@ NOTE: these flags are copied from https://github.com/AI-Hypercomputer/maxtext/bl
 Tested locally on v6e-8 doesnt seems to make a difference.
 
 ```bash
-cd ~/xla/experimental/torchax/examples/train_llama_torchtitan
+cd ~/torchax/examples/train_llama_torchtitan
 python train_llama.py --seqlen=8192
 ```
 

--- a/examples/train_llama_torchtitan/helper.py
+++ b/examples/train_llama_torchtitan/helper.py
@@ -44,8 +44,8 @@ def compile_step_func(step, weights, buffers, opt_state, args, label, mesh):
   step_compiled = lowered.compile()
   end = time.perf_counter()
   print('End compiling', end - start)
-  compile_time = end - start
   for co in step_compiled.cost_analysis():
-    print('Flops', co['flops'])
-    print('GB accessed', co['bytes accessed'] / 1e9)
+    print('Cost analysis:', co)
+    # print('Flops', co['flops'])
+    # print('GB accessed', co['bytes accessed'] / 1e9)
   return interop.torch_view(step_compiled)

--- a/examples/train_llama_torchtitan/splash_attn.py
+++ b/examples/train_llama_torchtitan/splash_attn.py
@@ -38,8 +38,6 @@ def tpu_splash_attention(
     decoder_segment_ids = splash_attention_kernel.SegmentIds(
         decoder_segment_ids, decoder_segment_ids)
 
-  print('HERE', locals())
-
   global_block_q = 1024
   global_block_kv = 512
   global_block_kv_compute = 512

--- a/examples/train_llama_torchtitan/train_llama.py
+++ b/examples/train_llama_torchtitan/train_llama.py
@@ -35,8 +35,8 @@ from jax.experimental import mesh_utils
 from jax.sharding import NamedSharding
 import optax
 
-from torchtitan.models.llama import llama3_configs
-from torchtitan.models.llama import model as titan
+from torchtitan.models.llama3 import llama3_args 
+from torchtitan.models.llama3.model import model as titan
 
 P = jax.sharding.PartitionSpec
 
@@ -291,7 +291,7 @@ def main(
   env.config.shmap_flash_attention = True
   env._mesh = mesh  # this is the mesh used by flash attention pallas kernel
 
-  args = llama3_configs[model_type]
+  args = llama3_args[model_type]
   # Note: torchtitan's upstream config did not specify this value
   args.vocab_size = 128256
   args.max_seq_len = seqlen
@@ -387,7 +387,7 @@ class TransfomerWithScan(torch.nn.Module):
     # for layer in self.layers.values():
     #     h = layer(h, self.freqs_cis)
 
-    h = self.layers(h, self.freqs_cis)
+    h = self.layers(h, self.freqs_cis, None)
 
     h = self.norm(h) if self.norm else h
     output = self.output(h) if self.output else h

--- a/torchax/tensor.py
+++ b/torchax/tensor.py
@@ -716,13 +716,14 @@ class Environment(contextlib.ContextDecorator):
         lambda x: mappings.t2j(x, self.config.use_dlpack_for_data_conversion),
         args)
 
-  def override_op_definition(self, op_to_override, op_impl):
+  def override_op_definition(self, op_to_override, op_impl, is_view_op=False):
     self._ops[op_to_override] = ops_registry.Operator(
         op_to_override,
         op_impl,
         is_jax_function=False,
         is_user_defined=True,
         needs_env=False,
+        is_view_op=is_view_op,
     )
 
   @contextlib.contextmanager


### PR DESCRIPTION
now runable with v6e4 vm:

```
0 loss Tensor(<class 'jaxlib._jax.ArrayImpl'> 278) step latency:  9.213168781949207
======
INPUT shape torch.Size([8, 2048])
1 loss Tensor(<class 'jaxlib._jax.ArrayImpl'> 278) step latency:  0.9060978279449046
======
INPUT shape torch.Size([8, 2048])
2 loss Tensor(<class 'jaxlib._jax.ArrayImpl'> 280) step latency:  0.9061213880777359
======
INPUT shape torch.Size([8, 2048])
3 loss Tensor(<class 'jaxlib._jax.ArrayImpl'> 280) step latency:  0.9060798480641097
======
```