### PR TITLE
offset2bag should be updated as a numpy array

### DIFF
--- a/torchax/ops/jaten.py
+++ b/torchax/ops/jaten.py
@@ -662,7 +662,7 @@ def _aten__embedding_bag(
         offsets_np = np.array(offsets)
     else:
         offsets_np = offsets
-    offset2bag = jnp.zeros(indices.shape[0], dtype=jnp.int64)
+    offset2bag = np.zeros(indices.shape[0], dtype=np.int64)
     bag_size = np.zeros(offsets_np.shape[0], dtype=np.int64)
     max_indices = jnp.full_like(indices, -1)
 
@@ -675,7 +675,7 @@ def _aten__embedding_bag(
             else offsets_np[bag + 1]
         )
         bag_size[bag] = end - start
-        offset2bag = offset2bag.at[start:end].set(bag)
+        offset2bag[start:end] = bag
 
         if end - start > 0:
             if mode == 0:


### PR DESCRIPTION
Found this when I tried to run ESM using torchax. It's a little bug where the `offset2bag` is being updated as if it was a JAX array while being a numpy array. 

Changed the update line. Fixes #43 