### PR TITLE
Solve deprecation warning since jax 0.8.0

### DIFF
--- a/torchax/interop.py
+++ b/torchax/interop.py
@@ -22,13 +22,17 @@ import jax
 import jax.numpy as jnp
 import torch
 from jax import tree_util as pytree
-from jax.experimental.shard_map import shard_map
 from torch.nn.utils import stateless as torch_stateless
 
 import torchax
 from torchax import tensor, util
 from torchax.ops import mappings
 from torchax.types import JaxCallable, JaxValue, TorchCallable, TorchValue
+
+try:
+  from jax import shard_map as shard_map  # for jax since v0.8.0
+except ImportError:
+  from jax.experimental.shard_map import shard_map
 
 
 def extract_all_buffers(m: torch.nn.Module):

--- a/torchax/ops/jtorch.py
+++ b/torchax/ops/jtorch.py
@@ -25,13 +25,17 @@ import numpy as np
 import torch
 import torch.utils._pytree as pytree
 from jax.experimental.pallas.ops.tpu import flash_attention
-from jax.experimental.shard_map import shard_map
 from jax.sharding import PartitionSpec
 
 import torchax.tensor
 from torchax.ops import jaten, jimage, mappings, op_base
 from torchax.ops.ops_registry import register_torch_function_op
 from torchax.view import NarrowInfo, View
+
+try:
+  from jax import shard_map as shard_map  # for jax since v0.8.0
+except ImportError:
+  from jax.experimental.shard_map import shard_map
 
 
 def register_function(torch_func, **kwargs):


### PR DESCRIPTION
shard_map was moved from jax.experimental to jax and it generates a DeprecationWarning since v0.8.0.

Sample output like

```text
/home/user/projects/torchax/torchax/interop.py:25: DeprecationWarning: jax.experimental.shard_map is deprecated in v0.8.0. Used jax.shard_map instead.
  from jax.experimental.shard_map import shard_map

```

Try import shard_map from `jax` first to avoid the DeprecationWarning, while preserving the compatibility to `jax` version before v0.8.0.

---

We can have some logic that depended on `importlib.metadata.version('jax')` or `jax.__verson_info__` if more robust logic is required.
