### PR TITLE
Fix few op related issues:

### DIFF
--- a/test/test_misc.py
+++ b/test/test_misc.py
@@ -90,9 +90,9 @@ class MiscTest(unittest.TestCase):
         self.assertTrue(torch.allclose(x, y))
 
     def test_zeros_with_explicit_size(self):
-        with torchax.default_env():
-            a = torch.zeros(size = (4,), device='jax')
-            self.assertEqual(a.shape[0], 4)
+      with torchax.default_env():
+        a = torch.zeros(size=(4,), device="jax")
+        self.assertEqual(a.shape[0], 4)
 
 
 if __name__ == "__main__":

--- a/test/test_ops_out.py
+++ b/test/test_ops_out.py
@@ -6,43 +6,42 @@ import torchax
 
 
 class OutVariantTest(unittest.TestCase):
+  def setUp(self):
+    self.env = torchax.default_env()
+    self.env.config.debug_print_each_op = True
 
-    def setUp(self):
-        self.env = torchax.default_env()
-        self.env.config.debug_print_each_op = True
+  def test_add_out(self):
+    with self.env:
+      a = torch.ones((2, 2), device="jax")
+      b = torch.ones((2, 2), device="jax")
+      c = torch.ones((2, 2), device="jax")
 
-    def test_add_out(self):
-        with self.env:
-            a = torch.ones((2,2), device='jax')
-            b = torch.ones((2,2), device='jax')
-            c = torch.ones((2,2), device='jax')
+      torch.add(a, b, out=c)
+      torch.testing.assert_close(c, a + b, check_device=False)
 
-            torch.add(a, b, out=c)
-            torch.testing.assert_close(c, a + b, check_device=False)
+  def test_sub_out(self):
+    with self.env:
+      a = torch.ones((2, 2), device="jax")
+      b = torch.ones((2, 2), device="jax")
+      c = torch.ones((2, 2), device="jax")
 
-    def test_sub_out(self):
-        with self.env:
-            a = torch.ones((2,2), device='jax')
-            b = torch.ones((2,2), device='jax')
-            c = torch.ones((2,2), device='jax')
+      torch.sub(a, b, out=c)
+      torch.testing.assert_close(c, a - b, check_device=False)
 
-            torch.sub(a, b, out=c)
-            torch.testing.assert_close(c, a - b, check_device=False)
+  def test_mul_out(self):
+    with self.env:
+      a = torch.ones((2, 2), device="jax")
+      b = torch.ones((2, 2), device="jax")
+      c = torch.ones((2, 2), device="jax")
 
-    def test_mul_out(self):
-        with self.env:
-            a = torch.ones((2,2), device='jax')
-            b = torch.ones((2,2), device='jax')
-            c = torch.ones((2,2), device='jax')
+      torch.mul(a, b, out=c)
+      torch.testing.assert_close(c, a * b, check_device=False)
 
-            torch.mul(a, b, out=c)
-            torch.testing.assert_close(c, a * b, check_device=False)
+  def test_div_out(self):
+    with self.env:
+      a = torch.ones((2, 2), device="jax")
+      b = torch.ones((2, 2), device="jax")
+      c = torch.ones((2, 2), device="jax")
 
-    def test_div_out(self):
-        with self.env:
-            a = torch.ones((2,2), device='jax')
-            b = torch.ones((2,2), device='jax')
-            c = torch.ones((2,2), device='jax')
-
-            torch.div(a, b, out=c)
-            torch.testing.assert_close(c, a / b, check_device=False)
+      torch.div(a, b, out=c)
+      torch.testing.assert_close(c, a / b, check_device=False)

--- a/torchax/ops/jaten.py
+++ b/torchax/ops/jaten.py
@@ -5812,7 +5812,9 @@ _out_variant_to_functional = {
   torch.ops.aten.logical_not.out: op_base.OutVariant(torch.ops.aten.logical_not),
   torch.ops.aten.log_normal.out: op_base.OutVariant(torch.ops.aten.log_normal),
   torch.ops.aten.scatter_add.out: op_base.OutVariant(torch.ops.aten.scatter_add),
-  torch.ops.aten.scatter_reduce.two_out: op_base.OutVariant(torch.ops.aten.scatter_reduce.two),
+  torch.ops.aten.scatter_reduce.two_out: op_base.OutVariant(
+    torch.ops.aten.scatter_reduce.two
+  ),
   torch.ops.aten.bitwise_not.out: op_base.OutVariant(torch.ops.aten.bitwise_not),
   torch.ops.aten.floor_divide.out: op_base.OutVariant(torch.ops.aten.floor_divide),
   torch.ops.aten.index_put.out: op_base.OutVariant(torch.ops.aten.index_put),
@@ -5837,10 +5839,10 @@ for operator, mutation in mutation_ops_to_functional.items():
   )
 
 for operator, definition in _out_variant_to_functional.items():
-    ops_registry.register_torch_dispatch_op(
-      operator,
-      definition,
-      is_jax_function=False,
-      is_view_op=True,
-      needs_env=False,
-    )
+  ops_registry.register_torch_dispatch_op(
+    operator,
+    definition,
+    is_jax_function=False,
+    is_view_op=True,
+    needs_env=False,
+  )

--- a/torchax/ops/jtorch.py
+++ b/torchax/ops/jtorch.py
@@ -285,8 +285,8 @@ def linalg_det(input):
 def _ones(*size: int, dtype=None, **kwargs):
   if len(size) == 1 and isinstance(size[0], collections.abc.Iterable):
     size = size[0]
-  if 'size' in kwargs:
-    size = kwargs['size']
+  if "size" in kwargs:
+    size = kwargs["size"]
   return jaten._ones(size, dtype=dtype)
 
 
@@ -294,8 +294,8 @@ def _ones(*size: int, dtype=None, **kwargs):
 def _zeros(*size: int, dtype=None, **kwargs):
   if len(size) == 1 and isinstance(size[0], collections.abc.Iterable):
     size = size[0]
-  if 'size' in kwargs:
-      size = kwargs['size']
+  if "size" in kwargs:
+    size = kwargs["size"]
   return jaten._zeros(size, dtype=dtype)
 
 
@@ -317,8 +317,8 @@ def _full(size: Sequence[int], fill_value, *, dtype=None, **kwargs):
 def empty(*size: Sequence[int], dtype=None, **kwargs):
   if len(size) == 1 and isinstance(size[0], collections.abc.Iterable):
     size = size[0]
-  if 'size' in kwargs:
-    size = kwargs['size']
+  if "size" in kwargs:
+    size = kwargs["size"]
   return jnp.empty(size, dtype=dtype)
 
 
@@ -365,8 +365,8 @@ def unravel_index(indices, shape):
 def rand(*size, **kwargs):
   if len(size) == 1 and isinstance(size[0], collections.abc.Iterable):
     size = size[0]
-  if 'size' in kwargs:
-    size = kwargs['size']
+  if "size" in kwargs:
+    size = kwargs["size"]
   return jaten._rand(size, **kwargs)
 
 

--- a/torchax/ops/op_base.py
+++ b/torchax/ops/op_base.py
@@ -64,19 +64,18 @@ class InplaceOp:
 
 
 class OutVariant:
+  def __init__(self, functional_op):
+    self.functional = functional_op
 
-    def __init__(self, functional_op):
-        self.functional = functional_op
-
-    def __call__(self, *args, **kwargs):
-        to_mutate: Tensor|View = kwargs["out"]
-        del kwargs["out"]
-        new_value= self.functional(*args, **kwargs)
-        if isinstance(to_mutate, View):
-            to_mutate.update(new_value)
-        else:
-            to_mutate._elem = new_value._elem
-        return to_mutate
+  def __call__(self, *args, **kwargs):
+    to_mutate: Tensor | View = kwargs["out"]
+    del kwargs["out"]
+    new_value = self.functional(*args, **kwargs)
+    if isinstance(to_mutate, View):
+      to_mutate.update(new_value)
+    else:
+      to_mutate._elem = new_value._elem
+    return to_mutate
 
 
 P = ParamSpec("P")

--- a/torchax/tensor.py
+++ b/torchax/tensor.py
@@ -422,7 +422,7 @@ class Environment(contextlib.ContextDecorator):
     for k, v in itertools.chain(
       ops_registry.all_aten_ops.items(), ops_registry.all_torch_functions.items()
     ):
-        self._ops[k] = v
+      self._ops[k] = v
 
     from torchax.decompositions import DECOMPOSITIONS, MUTABLE_DECOMPOSITION
 


### PR DESCRIPTION
* the out variant of ops currently raises. We can immitate those ops to certain extend by replacing the underlying Jax Array.
* When size passed as kwargs in some tensor constructors it constructs array incorrectly.