### PR TITLE
Resolve unintentional registration of add operator

### DIFF
--- a/torchax/ops/jaten.py
+++ b/torchax/ops/jaten.py
@@ -2402,7 +2402,6 @@ def _aten_atan2(input, other):
 
 # aten.bitwise_and
 @op(torch.ops.aten.bitwise_and)
-@op(torch.ops.aten.__and__)
 def _aten_bitwise_and(self, other):
   return self & other
 


### PR DESCRIPTION
Also resolve following warning message as a side effect.

"WARNING:root:Duplicate op registration for aten.__and__"

---

Here we remove the 1st registration of `aten.__and__` since that the 2nd registration is always [overwriting the first registration](https://github.com/google/torchax/blob/85c7ab94addba6335af85b89ae67704c73091d62/torchax/ops/ops_registry.py#L53). This change preserves original behavior.