### PR TITLE
Correct the dev package to use YYYYMMDD naming

### DIFF
--- a/scripts/update_to_nightly_version.py
+++ b/scripts/update_to_nightly_version.py
@@ -8,7 +8,7 @@ TARGET_FILE = Path("torchax/__init__.py")
 
 def update_version():
     nightly_date = datetime.date.today()
-    date_str = '{}{}{}'.format(nightly_date.year, nightly_date.month, nightly_date.day)
+    date_str = f'{nightly_date.year:04d}{nightly_date.month:02d}{nightly_date.day:02d}'
 
     # 2. Check if the target file exists
     if not TARGET_FILE.exists():


### PR DESCRIPTION
Pad the dev package name with proper zeros to enhance readability.

Currently the nightly package at 2026/01/08 will be marked with `0.0.11.dev202618`, not quite useful.

See: <https://pypi.org/project/torchax/#history>