### PR TITLE
Replace deprecated assert_allclose with assert_close

### DIFF
--- a/test/test_interop.py
+++ b/test/test_interop.py
@@ -127,7 +127,7 @@ class InteropTest(unittest.TestCase):
     actual = m_jitted(x)
 
     # assert
-    torch.testing.assert_allclose(actual, expected)
+    torch.testing.assert_close(actual, expected)
 
     # arrange
     # make sure buffer donation works
@@ -139,7 +139,7 @@ class InteropTest(unittest.TestCase):
     # act
     actual = functional_forward(m_jitted.params, m_jitted.buffers, x)
     # assert
-    torch.testing.assert_allclose(actual, expected)
+    torch.testing.assert_close(actual, expected)
 
   def test_to_jax_device(self):
     a = torch.ones(3, 3)

--- a/test/test_train.py
+++ b/test/test_train.py
@@ -46,7 +46,9 @@ class TrainTest(unittest.TestCase):
       x = x.to("jax")
       model.to("jax")
       result2 = model(x)
-      torch.testing.assert_allclose(result, result2.to("cpu"))
+      # Explicit rtol/atol match previous assert_allclose's defaults for float32 (1e-4 / 1e-5)
+      # to accommodate small numerical drift accumulating from eager loop vs ScannedModule executions.
+      torch.testing.assert_close(result, result2.to("cpu"), rtol=1e-4, atol=1e-5)
 
   def test_train_step_can_run(self):
     import optax


### PR DESCRIPTION
Tidy up warning message during running test cases.

> FutureWarning: `torch.testing.assert_allclose()` is deprecated since 1.12 and will be removed in a future release. 