### PR TITLE
Track more functions as TENSOR_CONSTRUCTORS

### DIFF
--- a/torchax/tensor.py
+++ b/torchax/tensor.py
@@ -298,6 +298,8 @@ TENSOR_CONSTRUCTORS = {
   torch.randint,
   torch.full,
   torch.as_tensor,
+  torch.linspace,
+  torch.logspace,
 }
 
 # TODO(wen): use existing types, either from torch or jax


### PR DESCRIPTION
Add linspace and logspace.

```python
import torch
import torchax

torchax.enable_globally()
tensor = torch.linspace(3, 10, 5, device=torch.device('cpu'))
print(tensor.device)
```

Before the fix

```
jax:0
```

After

```
cpu
```
