### PR TITLE
feat: static shape jaten ops for multimodal embedding

### DIFF
--- a/test/test_core_aten_ops.py
+++ b/test/test_core_aten_ops.py
@@ -1839,7 +1839,29 @@ class TestCoreAtenOps(unittest.TestCase):
     kwargs = {}
     run_export_and_compare(self, torch.ops.aten.index_put, args, kwargs)
 
+  def test_aten_index_put_boolean_mask_scalar(self):
+
+    mask = torch.tensor([[True, False, True], [False, True, False]])
+    args = (
+      torch.zeros((2, 3)).to(torch.float32),
+      [mask],
+      torch.tensor(5.0).to(torch.float32),
+    )
+    kwargs = {}
+    run_export_and_compare(self, torch.ops.aten.index_put, args, kwargs)
+
+  def test_aten_index_put_boolean_mask_tensor(self):
+    mask = torch.tensor([[True, False, True], [False, True, False]])
+    args = (
+      torch.zeros((2, 3)).to(torch.float32),
+      [mask],
+      torch.tensor([10.0, 20.0, 30.0]).to(torch.float32),
+    )
+    kwargs = {}
+    run_export_and_compare(self, torch.ops.aten.index_put, args, kwargs)
+
   def test_aten_index_select_0(self):
+
     args = (
       torch.randn((2, 10)).to(torch.float32),
       1,
@@ -2245,7 +2267,18 @@ class TestCoreAtenOps(unittest.TestCase):
     kwargs = {}
     run_export_and_compare(self, torch.ops.aten.lt.Tensor, args, kwargs)
 
+  def test_aten_masked_scatter_0(self):
+    mask = torch.tensor([[True, False, True], [False, True, False]])
+    args = (
+      torch.zeros((2, 3)).to(torch.float32),
+      mask,
+      torch.tensor([10.0, 20.0, 30.0, 40.0, 50.0]).to(torch.float32),
+    )
+    kwargs = {}
+    run_export_and_compare(self, torch.ops.aten.masked_scatter, args, kwargs)
+
   def test_aten_masked_fill_Scalar_0(self):
+
     args = (
       torch.randn((10, 10)).to(torch.float32),
       torch.randn((10, 10)).to(torch.bool),

--- a/torchax/ops/jaten.py
+++ b/torchax/ops/jaten.py
@@ -763,10 +763,80 @@ def _aten_empty_strided(sizes, stride, dtype=None, **kwargs):
   return jnp.empty(sizes, dtype=dtype)
 
 
+def _shape_static_boolean_index_put(self, mask, values, accumulate=False):
+  # Align mask dimensions to the left of self dimensions (PyTorch convention)
+  if mask.ndim < self.ndim:
+    expanded_mask = jnp.expand_dims(mask, axis=list(range(mask.ndim, self.ndim)))
+    broadcasted_mask = jnp.broadcast_to(expanded_mask, self.shape)
+  else:
+    broadcast_shape = jnp.broadcast_shapes(self.shape, mask.shape)
+    if self.shape != broadcast_shape:
+      self = jnp.broadcast_to(self, broadcast_shape)
+    if mask.shape != broadcast_shape:
+      broadcasted_mask = jnp.broadcast_to(mask, broadcast_shape)
+    else:
+      broadcasted_mask = mask
+
+  is_scalar = not hasattr(values, "shape") or len(values.shape) == 0
+
+  if is_scalar or (hasattr(values, "shape") and values.shape == self.shape):
+    if accumulate:
+      return jnp.where(broadcasted_mask, self + values, self)
+    else:
+      return jnp.where(broadcasted_mask, values, self)
+
+  # General case: Dummy Row pattern
+  self_flat = self.flatten()
+  mask_flat = broadcasted_mask.flatten()
+  val_flat = values.flatten()
+
+  # Target length from self
+  target_len = self_flat.shape[0]
+  curr_val_len = val_flat.shape[0]
+
+  # Pad val_flat to ensure the operand shape is static [target_len, ...]
+  if curr_val_len < target_len:
+    padding = jnp.zeros(
+      (target_len - curr_val_len,) + val_flat.shape[1:], dtype=val_flat.dtype
+    )
+    val_flat = jnp.concatenate([val_flat, padding], axis=0)
+
+  # Now perform the Dummy Row concatenation
+  zero_row = jnp.zeros((1,) + val_flat.shape[1:], dtype=val_flat.dtype)
+  padded_val = jnp.concatenate([zero_row, val_flat], axis=0)
+
+  # 2. Cumulative sum of mask_flat to find indices directly.
+  # Cumsum is 1-based index count of True elements.
+  # Every False position before the first True will be 0 (pointing to dummy row).
+  # Every True position will point to its corresponding 1-based index in padded_val.
+  mask_int = mask_flat.astype(jnp.int32)
+  idx = jnp.cumsum(mask_int)
+
+  # 3. Gather elements from padded_val using idx directly (no clip, no -1)
+  values_from_source = padded_val[idx]
+
+  # 4. Use jnp.where to write elements only where mask is True
+  if accumulate:
+    self_flat = jnp.where(mask_flat, self_flat + values_from_source, self_flat)
+  else:
+    self_flat = jnp.where(mask_flat, values_from_source, self_flat)
+
+  return self_flat.reshape(self.shape)
+
+
 @op(torch.ops.aten.index_put)
 def _aten_index_put(self, indexes, values, accumulate=False):
   indexes = [slice(None, None, None) if i is None else i for i in indexes]
   indexes = tuple(indexes)
+
+  # Detect single boolean mask indexing
+  if (
+    len(indexes) == 1
+    and isinstance(indexes[0], jax.Array)
+    and indexes[0].dtype == jnp.bool_
+  ):
+    return _shape_static_boolean_index_put(self, indexes[0], values, accumulate)
+
   if accumulate:
     return self.at[indexes].add(values)
   else:
@@ -1788,22 +1858,7 @@ def _aten_scatter_add(input, dim, index, src):
 # aten.masked_scatter
 @op(torch.ops.aten.masked_scatter)
 def _aten_masked_scatter(self, mask, source):
-  broadcast_shape = jnp.broadcast_shapes(self.shape, mask.shape)
-
-  if self.shape != broadcast_shape:
-    self = jnp.broadcast_to(self, broadcast_shape)
-  elif mask.shape != broadcast_shape:
-    mask = jnp.broadcast_to(mask, broadcast_shape)
-
-  self_flat = self.flatten()
-  mask_flat = mask.flatten()
-  source_flat = source.flatten()
-
-  true_indices = jnp.where(mask_flat)[0]
-  self_flat = self_flat.at[true_indices].set(source_flat[: len(true_indices)])
-  final_arr = self_flat.reshape(self.shape)
-
-  return final_arr
+  return _shape_static_boolean_index_put(self, mask, source)
 
 
 @op(torch.ops.aten.masked_select)

--- a/torchax/ops/jaten.py
+++ b/torchax/ops/jaten.py
@@ -763,9 +763,11 @@ def _aten_empty_strided(sizes, stride, dtype=None, **kwargs):
   return jnp.empty(sizes, dtype=dtype)
 
 
-def _shape_static_boolean_index_put(self, mask, values, accumulate=False):
-  # Align mask dimensions to the left of self dimensions (PyTorch convention)
-  if mask.ndim < self.ndim:
+def _shape_static_boolean_index_put(
+  self, mask, values, accumulate=False, is_sequential=False, left_align_mask=True
+):
+  # Align mask dimensions to self dimensions
+  if left_align_mask and mask.ndim < self.ndim:
     expanded_mask = jnp.expand_dims(mask, axis=list(range(mask.ndim, self.ndim)))
     broadcasted_mask = jnp.broadcast_to(expanded_mask, self.shape)
   else:
@@ -777,24 +779,43 @@ def _shape_static_boolean_index_put(self, mask, values, accumulate=False):
     else:
       broadcasted_mask = mask
 
-  is_scalar = not hasattr(values, "shape") or len(values.shape) == 0
+  # index_put with scalars or compatible tensors
+  val_shape = getattr(values, "shape", ())
+  val_size = getattr(values, "size", 1)
 
-  if is_scalar or (hasattr(values, "shape") and values.shape == self.shape):
+  is_effectively_scalar = (len(val_shape) == 0) or (val_size == 1)
+  is_same_shape = val_shape == self.shape
+  is_slice_broadcast = (mask.ndim < self.ndim) and (
+    val_shape == self.shape[mask.ndim :]
+  )
+
+  if not is_sequential and (
+    is_effectively_scalar or is_same_shape or is_slice_broadcast
+  ):
+    values_broadcasted = jnp.broadcast_to(values, self.shape)
     if accumulate:
-      return jnp.where(broadcasted_mask, self + values, self)
+      return jnp.where(broadcasted_mask, self + values_broadcasted, self)
     else:
-      return jnp.where(broadcasted_mask, values, self)
+      return jnp.where(broadcasted_mask, values_broadcasted, self)
 
   # General case: Dummy Row pattern
   self_flat = self.flatten()
   mask_flat = broadcasted_mask.flatten()
+
+  # Broadcast values suffix dimensions to suffix_shape
+  suffix_shape = self.shape[mask.ndim :]
+  if not is_sequential:
+    if len(val_shape) == len(suffix_shape) + 1:
+      target_val_shape = (values.shape[0],) + suffix_shape
+      values = jnp.broadcast_to(values, target_val_shape)
+
   val_flat = values.flatten()
 
   # Target length from self
   target_len = self_flat.shape[0]
   curr_val_len = val_flat.shape[0]
 
-  # Pad val_flat to ensure the operand shape is static [target_len, ...]
+  # Pad to max sequence length to ensure static HLO
   if curr_val_len < target_len:
     padding = jnp.zeros(
       (target_len - curr_val_len,) + val_flat.shape[1:], dtype=val_flat.dtype
@@ -805,23 +826,23 @@ def _shape_static_boolean_index_put(self, mask, values, accumulate=False):
   zero_row = jnp.zeros((1,) + val_flat.shape[1:], dtype=val_flat.dtype)
   padded_val = jnp.concatenate([zero_row, val_flat], axis=0)
 
-  # 2. Cumulative sum of mask_flat to find indices directly.
+  # Cumulative sum of mask_flat to find indices directly.
   # Cumsum is 1-based index count of True elements.
   # Every False position before the first True will be 0 (pointing to dummy row).
   # Every True position will point to its corresponding 1-based index in padded_val.
   mask_int = mask_flat.astype(jnp.int32)
   idx = jnp.cumsum(mask_int)
 
-  # 3. Gather elements from padded_val using idx directly (no clip, no -1)
+  # Gather elements from padded_val using idx directly (no clip, no -1)
   values_from_source = padded_val[idx]
 
-  # 4. Use jnp.where to write elements only where mask is True
+  # Use jnp.where to write elements only where mask is True
   if accumulate:
-    self_flat = jnp.where(mask_flat, self_flat + values_from_source, self_flat)
+    res_flat = jnp.where(mask_flat, self_flat + values_from_source, self_flat)
   else:
-    self_flat = jnp.where(mask_flat, values_from_source, self_flat)
+    res_flat = jnp.where(mask_flat, values_from_source, self_flat)
 
-  return self_flat.reshape(self.shape)
+  return res_flat.reshape(self.shape)
 
 
 @op(torch.ops.aten.index_put)
@@ -835,7 +856,9 @@ def _aten_index_put(self, indexes, values, accumulate=False):
     and isinstance(indexes[0], jax.Array)
     and indexes[0].dtype == jnp.bool_
   ):
-    return _shape_static_boolean_index_put(self, indexes[0], values, accumulate)
+    return _shape_static_boolean_index_put(
+      self, indexes[0], values, accumulate, is_sequential=False
+    )
 
   if accumulate:
     return self.at[indexes].add(values)
@@ -1858,7 +1881,9 @@ def _aten_scatter_add(input, dim, index, src):
 # aten.masked_scatter
 @op(torch.ops.aten.masked_scatter)
 def _aten_masked_scatter(self, mask, source):
-  return _shape_static_boolean_index_put(self, mask, source)
+  return _shape_static_boolean_index_put(
+    self, mask, source, is_sequential=True, left_align_mask=False
+  )
 
 
 @op(torch.ops.aten.masked_select)

--- a/torchax/tensor.py
+++ b/torchax/tensor.py
@@ -107,7 +107,16 @@ class Tensor(torch.Tensor):
 
   def __setitem__(self, key, val):
     key, val = self._env.t2j_iso((key, val))
-    self._elem = self._elem.at[key].set(val)
+    actual_key = key
+    if isinstance(key, tuple) and len(key) == 1:
+      actual_key = key[0]
+
+    if isinstance(actual_key, jax.Array) and actual_key.dtype == jnp.bool_:
+      from torchax.ops.jaten import _shape_static_boolean_index_put
+
+      self._elem = _shape_static_boolean_index_put(self._elem, actual_key, val)
+    else:
+      self._elem = self._elem.at[key].set(val)
 
   def type_as(self, other):
     self._elem = self._elem.astype(other._elem.dtype)

--- a/torchax/tensor.py
+++ b/torchax/tensor.py
@@ -114,7 +114,9 @@ class Tensor(torch.Tensor):
     if isinstance(actual_key, jax.Array) and actual_key.dtype == jnp.bool_:
       from torchax.ops.jaten import _shape_static_boolean_index_put
 
-      self._elem = _shape_static_boolean_index_put(self._elem, actual_key, val)
+      self._elem = _shape_static_boolean_index_put(
+        self._elem, actual_key, val, is_sequential=False
+      )
     else:
       self._elem = self._elem.at[key].set(val)
 


### PR DESCRIPTION
<!-- markdownlint-disable -->
## Problem:
When running multimodal models (e.g., **Gemma-4 31B**) via Torchax on TPU, standard PyTorch boolean indexing (e.g., `x[mask] = y`) is lowered to dynamic `lax.scatter` operations in XLA. 

Because of **Variable Resolution** in multimodal inputs, the number of tokens (the sum of the boolean mask) fluctuates across requests. This forces XLA to treat each unique mask count as a new graph signature, triggering recurring **13s–15s recompilation pauses** during the runtime.

## Solution: 
This PR reimplements boolean indexing in the Torchax framework to be **fully shape-static**. Instead of dynamic coordinate generation, we use a vectorized mapping pattern:

1. **Operand Padding**: We pad the update values to the target sequence length, ensuring the `gather` operand has a fixed shape.
2. **Prepend Dummy Row**: We add a zero-filled row at index 0 of the source array.
3. **Static Indexing (Cumsum)**: We use `jnp.cumsum(mask)` to generate a 1-based index map. `False` positions naturally point to the dummy row (index 0), while `True` positions point sequentially to the valid values.
4. **Pointwise Select**: We use `jnp.where` for the final assignment. This allows XLA to fuse the entire pipeline into a single **pointwise fusion kernel**.

## Key Changes
- **`torchax/tensor.py`**: Intercepted `__setitem__` to redirect boolean indexing to the new static path.
- **`torchax/ops/jaten.py`**: Rewrote `_aten_index_put` and `_aten_masked_scatter` to provide global coverage for this optimization.

## Performance Impact (Verified on TPU v7x)
- **Elimination of Recompilation**: After the initial warmup compilation, the repetitive 13s - 15s `jit(scatter)` gaps are completely eliminated.
- **JAX Parity**: End-to-End benchmarking on 320 random MM prompts shows that vLLM-on-Torchax now achieves **duration parity** with the reference flax_nnx implementation.

## Test Plan
- Run numerical parity tests to ensure bit-identical results with original PyTorch indexing:
  `pytest test/test_core_aten_ops.py -k "index_put"`
- Gemma4 - Verified on TPU v7x-8 nodes using vLLM production workloads.

**Before**
<img width="2986" height="940" alt="BmAiEjfP6fwpuKi" src="https://github.com/user-attachments/assets/1017c580-f95b-4d61-96dc-5b3d366ab50f" />
**After**
<img width="2128" height="923" alt="Bn9vQjdKM3VXHkF" src="https://github.com/user-attachments/assets/d286d92f-5d9e-4c96-bec2-0e37d34c7590" />

## Notes

A parallel PR in the vLLM repository ([PR #44474](https://github.com/vllm-project/vllm/pull/44474) involves a higher-level modification with broader implications—including **potential benefits for TorchTPU**. It can also cover the repetitive multi-modal embedding recompilation issue observed for Gemma-4, which may require extended coordination with community to finalize.

