### PR TITLE
Allow Tensor/View ops outside XLADispatchMode by delegating to env.dispatch()

### DIFF
--- a/test/test_context.py
+++ b/test/test_context.py
@@ -20,6 +20,7 @@ import torch
 import torchax
 import torchax.interop
 from torchax import tensor
+from torchax.view import View
 
 xla_env = torchax.default_env()
 
@@ -31,6 +32,33 @@ class TestContext(unittest.TestCase):
       self.assertIsInstance(x, tensor.Tensor)
       y = x.abs()
       self.assertIsInstance(y, tensor.Tensor)
+
+  def test_arithmetic_outside_dispatch_mode(self):
+    # Tensors created inside `with xla_env:` remain torchax Tensor/View
+    # instances after the block exits, even though XLADispatchMode is no
+    # longer active. Ops on them then reach Tensor.__torch_dispatch__ /
+    # View.__torch_dispatch__ directly (the tensor-subclass fallback),
+    # rather than XLADispatchMode.__torch_dispatch__. This happens in
+    # practice when torchax tensors are captured by, and later used inside,
+    # a torch.compile/AOT-lowered region that runs outside `with xla_env:`.
+    with xla_env:
+      x = torch.ones((4, 4), device="jax")
+      y = torch.ones((4, 4), device="jax")
+      y_view = y[:, :]
+
+    self.assertIsInstance(x, tensor.Tensor)
+    self.assertIsInstance(y_view, View)
+    self.assertFalse(xla_env.enabled)
+
+    # Tensor + Tensor, outside the dispatch mode.
+    z1 = x + y
+    self.assertEqual(z1.sum().item(), 32.0)
+
+    # Tensor + View, outside the dispatch mode. Tensor is the left operand,
+    # so Tensor.__torch_dispatch__ (not View's) handles it first and must
+    # delegate to env.dispatch() rather than raise.
+    z2 = x + y_view
+    self.assertEqual(z2.sum().item(), 32.0)
 
   @staticmethod
   @xla_env

--- a/torchax/tensor.py
+++ b/torchax/tensor.py
@@ -122,6 +122,18 @@ class Tensor(torch.Tensor):
       return args[0]._env.dispatch(func, types, args, kwargs)
     if func == torch.ops.prim.device.default:
       return torch.device("privateuseone", 0)
+    # Delegate to env.dispatch() when called outside XLADispatchMode.
+    # This handles ops like `Tensor + View` or `Tensor + Tensor` that arise
+    # when torchax tensors are used without an active dispatch mode context
+    # (e.g. during AOT lower where XLADispatchMode is not installed).
+    # env.dispatch() calls v2t_iso() to materialise any View args before
+    # running the JAX op.
+    kwargs = kwargs or {}
+    from torchax.view import View
+    flat = list(args) + list(kwargs.values())
+    env_holder = next((a for a in flat if isinstance(a, (Tensor, View))), None)
+    if env_holder is not None:
+      return env_holder._env.dispatch(func, types, args, kwargs)
     raise AssertionError(
       "torchax Tensors can only do math within the torchax environment."
       "Please wrap your code with `with torchax.default_env()` or "

--- a/torchax/tensor.py
+++ b/torchax/tensor.py
@@ -130,6 +130,7 @@ class Tensor(torch.Tensor):
     # running the JAX op.
     kwargs = kwargs or {}
     from torchax.view import View
+
     flat = list(args) + list(kwargs.values())
     env_holder = next((a for a in flat if isinstance(a, (Tensor, View))), None)
     if env_holder is not None:

--- a/torchax/view.py
+++ b/torchax/view.py
@@ -353,6 +353,16 @@ class View(torch.Tensor):
     args: tuple[Any, ...] = (),
     kwargs: dict | None = None,
   ) -> Any:
+    kwargs = kwargs or {}
+    # If a View is present in the args, delegate to its env so that View
+    # participates in arithmetic (e.g. View + Tensor) even when no
+    # XLADispatchMode context manager is active.  env.dispatch() calls
+    # v2t_iso() which materialises the View to a Tensor before the op runs.
+    view = next((a for a in args if isinstance(a, View)), None)
+    if view is None:
+      view = next((a for a in kwargs.values() if isinstance(a, View)), None)
+    if view is not None:
+      return view._env.dispatch(func, types, args, kwargs)
     raise AssertionError(
       "torchax Tensors can only do math within the torchax environment."
       "Please wrap your code with `with torchax.default_env()` or "


### PR DESCRIPTION
`Tensor.__torch_dispatch__` and `View.__torch_dispatch__` previously raised `AssertionError` unconditionally for any op other than `wait_tensor`/`prim.device`. This caused `TypeError` when torchax tensors were used in arithmetic outside an active `XLADispatchMode` context — for example during vLLM AOT lower, where `XLADispatchMode` is not installed but torchax Tensors and Views appear as arguments to aten ops (e.g. Tensor + View from deepstack vision features).

Fix: before raising, scan args/kwargs for the first Tensor or View and delegate to its `_env.dispatch()`. `env.dispatch()` calls `v2t_iso()` which materializes any View arguments to Tensors, then `t2j_iso()` converts to JAX arrays and runs the op. This matches the behaviour already provided by `XLADispatchMode` when that mode is active.

The `View.__torch_dispatch__` change handles the View-as-left-operand case. The `Tensor.__torch_dispatch__` change is the primary fix: for Tensor + View, Python dispatches to Tensor first (left operand), so `View.__torch_dispatch__` is never reached unless Tensor's dispatch succeeds or returns NotImplemented.