### PR TITLE
Remove `torch.cholesky` overrides

### DIFF
--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -30,6 +30,7 @@ skiplist = {
   "_segment_reduce",
   "bincount",  # NOTE: dtype for int input torch gives float. This is weird.
   "byte",
+  "cholesky", # To be removed from PyTorch, still covered by linalg.cholesky
   "cholesky_solve",
   "geqrf",
   "histogram",  # hard op: AssertionError: Tensor-likes are not close!

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -30,7 +30,7 @@ skiplist = {
   "_segment_reduce",
   "bincount",  # NOTE: dtype for int input torch gives float. This is weird.
   "byte",
-  "cholesky", # To be removed from PyTorch, still covered by linalg.cholesky
+  "cholesky",  # To be removed from PyTorch, still covered by linalg.cholesky
   "cholesky_solve",
   "geqrf",
   "histogram",  # hard op: AssertionError: Tensor-likes are not close!

--- a/torchax/amp.py
+++ b/torchax/amp.py
@@ -128,7 +128,6 @@ autocast_policy = {
   torch.ops.aten.grid_sampler_3d.default: CastPolicy.FP32,
   torch.ops.aten.trace.default: CastPolicy.FP32,
   torch.ops.aten.view_as_complex.default: CastPolicy.FP32,
-  torch.ops.aten.cholesky.default: CastPolicy.FP32,
   torch.ops.aten.cholesky_inverse.default: CastPolicy.FP32,
   torch.ops.aten.cholesky_solve.default: CastPolicy.FP32,
   torch.ops.aten.inverse.default: CastPolicy.FP32,

--- a/torchax/ops/jaten.py
+++ b/torchax/ops/jaten.py
@@ -203,7 +203,7 @@ def _aten_index_select(x, dim, index):
   return jnp.take(x, index, dim)
 
 
-@op(torch.ops.aten.cholesky)
+@op(torch.ops.aten.linalg_cholesky)
 def _aten_cholesky(input, upper=False):
   return jax.scipy.linalg.cholesky(input, lower=(not upper))
 


### PR DESCRIPTION
`torch.cholesky` has been an alias for `torch.linalg.cholesky` for several years and is getting removed by https://github.com/pytorch/pytorch/pull/186817

Update the repo to use `torch.linalg.cholesky`

Add `torch.cholesky` to skiplist, but check that `torch.linalg.cholesky` tests are still running
```
% python test/test_ops.py -v -k cholesky                                                              
op_db size:  697 testing:  657
test_reference_eager_cholesky_inverse_cpu_float32 (__main__.TestOpInfoCPU.test_reference_eager_cholesky_inverse_cpu_float32) ... ok
test_reference_eager_linalg_cholesky_cpu_float32 (__main__.TestOpInfoCPU.test_reference_eager_linalg_cholesky_cpu_float32) ... ok
test_reference_eager_linalg_cholesky_ex_cpu_float32 (__main__.TestOpInfoCPU.test_reference_eager_linalg_cholesky_ex_cpu_float32) ... ok

----------------------------------------------------------------------
Ran 3 tests in 0.788s

OK
```